### PR TITLE
Update telegram channel python and add readme hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,9 @@ Some options can be set via an environment variable (real or [dotenv](https://gi
         -p qwerty123 \
         ...
     ```
+## Developer hints
+
+When using a non-docker or git version ( e.g. in venv), the required packages can be obtained with:
+```
+pip3 install sentry_sdk imap_tools telegram pyyaml click requests dotenv bs4   python-telegram-bot
+```

--- a/imapmon/channels/tg.py
+++ b/imapmon/channels/tg.py
@@ -1,7 +1,11 @@
 from click import BadOptionUsage
 from bs4 import BeautifulSoup
 from imap_tools import MailMessage
-from telegram import Bot, ParseMode
+#from telegram import Bot, ParseMode
+#as per Version 20 you need to use: (https://stackoverflow.com/a/74180161)
+from telegram import Bot
+from telegram.constants import ParseMode
+
 
 from imapmon.settings import Settings
 from imapmon.channels.base import BaseChannel


### PR DESCRIPTION
did not work in python-3.9  when not using docker

```
ImportError: cannot import name 'ParseMode' from 'telegram'
```
https://stackoverflow.com/questions/69155789/importerror-cannot-import-name-parsemode-from-telegram

added hints in readme to deploy non-docker environment quickly